### PR TITLE
Document Overture GitHub Projects board contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,10 @@ Start here when working in this repository.
 4. `docs/README.md`
 5. `docs/design-docs/index.md`
 6. `docs/product-specs/index.md`
-7. `docs/PLANS.md`
-8. `elixir/AGENTS.md`
-9. `elixir/WORKFLOW.md`
+7. `docs/references/index.md`
+8. `docs/PLANS.md`
+9. `elixir/AGENTS.md`
+10. `elixir/WORKFLOW.md`
 
 ## Repository map
 
@@ -34,6 +35,9 @@ docs/
 ├── exec-plans/
 │   └── active/
 │       └── overture-github-projects-migration.md
+├── references/
+│   ├── index.md
+│   └── github-projects-board-metadata.md
 └── product-specs/
     ├── index.md
     ├── current-runtime-baseline.md

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,4 +64,5 @@ The migration is intentionally staged.
 - `docs/design-docs/tracker-identity-and-routing.md`
 - `docs/product-specs/current-runtime-baseline.md`
 - `docs/product-specs/github-projects-runtime-contract.md`
+- `docs/references/github-projects-board-metadata.md`
 - `docs/exec-plans/active/overture-github-projects-migration.md`

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -6,6 +6,7 @@ Created: 2026-03-12
 
 - Delivery board: <https://github.com/orgs/BrandByX/projects/6>
 - Sandbox board: <https://github.com/orgs/BrandByX/projects/5>
+- Live board metadata: `references/github-projects-board-metadata.md`
 
 ## Active execution plan
 
@@ -25,5 +26,5 @@ Created: 2026-03-12
 ## Planning notes
 
 - Ticket `#1` establishes the public-facing fork and harness baseline.
-- Ticket `#2` owns the GitHub Projects board contract and field semantics.
+- Ticket `#2` owns the GitHub Projects board contract, field semantics, and live metadata capture.
 - Tickets `#3` through `#8` are the implementation sequence for the GitHub Projects runtime fork.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ This directory holds the canonical migration and design docs for the Overture fo
 - `PLANS.md`: execution program index and board links
 - `design-docs/`: durable design decisions for the fork
 - `product-specs/`: target runtime and tracker contract
+- `references/`: live environment metadata and operator-facing reference values
 - `exec-plans/active/`: active implementation sequencing
 
 ## Start here
@@ -20,3 +21,4 @@ This directory holds the canonical migration and design docs for the Overture fo
 - `PLANS.md`
 - `design-docs/index.md`
 - `product-specs/index.md`
+- `references/index.md`

--- a/docs/exec-plans/active/overture-github-projects-migration.md
+++ b/docs/exec-plans/active/overture-github-projects-migration.md
@@ -12,6 +12,7 @@ that can poll, execute, update, and validate issue-backed project items.
 - The repo is publicly branded as Overture
 - The current Elixir runtime remains Linear-oriented
 - GitHub Projects boards are already created and configured operationally
+- Live board IDs, field IDs, and option IDs are captured in `docs/references/github-projects-board-metadata.md`
 - The migration work is tracked on the Overture Delivery board
 
 ## Target state

--- a/docs/references/github-projects-board-metadata.md
+++ b/docs/references/github-projects-board-metadata.md
@@ -1,0 +1,125 @@
+# GitHub Projects Board Metadata
+
+Created: 2026-03-13
+
+## Purpose
+
+Capture the live GitHub Projects board metadata that future runtime and smoke-test tickets need
+without mixing those environment-specific values into the generic runtime contract docs.
+
+## Owner and repository
+
+- owner login: `BrandByX`
+- repository: `BrandByX/overture`
+- owner type for runtime config: `organization`
+
+## Delivery board
+
+- board name: `Overture Delivery`
+- board number: `6`
+- board URL: <https://github.com/orgs/BrandByX/projects/6>
+- board node ID: `PVT_kwDOCZhNHc4BRmMe`
+- purpose: canonical implementation tracking board for Overture work
+
+### Delivery Status field
+
+- field name: `Status`
+- field type: `ProjectV2SingleSelectField`
+- field node ID: `PVTSSF_lADOCZhNHc4BRmMezg_YP7A`
+
+### Delivery Status options
+
+- `Backlog` -> `9e04ac26`
+- `Todo` -> `ec18a1c6`
+- `In Progress` -> `cdb65b21`
+- `Human Review` -> `e9d11d04`
+- `Rework` -> `867a2bb7`
+- `Merging` -> `7a93fdf1`
+- `Done` -> `01fb8d27`
+- `Cancelled` -> `d671fce9`
+- `Duplicate` -> `7b773efb`
+
+## Sandbox board
+
+- board name: `Overture Sandbox`
+- board number: `5`
+- board URL: <https://github.com/orgs/BrandByX/projects/5>
+- board node ID: `PVT_kwDOCZhNHc4BRmMf`
+- purpose: dogfooding board for live validation and smoke-test runs
+
+### Sandbox Status field
+
+- field name: `Status`
+- field type: `ProjectV2SingleSelectField`
+- field node ID: `PVTSSF_lADOCZhNHc4BRmMfzg_YP7E`
+
+### Sandbox Status options
+
+- `Backlog` -> `6362c745`
+- `Todo` -> `4c006868`
+- `In Progress` -> `357fccd6`
+- `Human Review` -> `0208e9a5`
+- `Rework` -> `86458504`
+- `Merging` -> `57d0f6cc`
+- `Done` -> `099b1125`
+- `Cancelled` -> `1dda1f75`
+- `Duplicate` -> `67952265`
+
+## Workflow semantics
+
+- non-active holding state:
+  - `Backlog`
+- active states:
+  - `Todo`
+  - `In Progress`
+  - `Human Review`
+  - `Rework`
+  - `Merging`
+- terminal states:
+  - `Done`
+  - `Cancelled`
+  - `Duplicate`
+
+These semantics must stay aligned with the runtime contract in
+`docs/product-specs/github-projects-runtime-contract.md`.
+
+## Board intake policy
+
+The current board intake policy is explicit rather than implicit.
+
+- `Overture Delivery` is the canonical location for implementation tickets.
+- `Overture Sandbox` is reserved for dogfooding and live validation.
+- New repository issues should be added to `Overture Delivery` intentionally.
+- Sandbox issues should be added to `Overture Sandbox` intentionally.
+
+## Workflow automation state
+
+Observed GitHub Project workflows as of 2026-03-13:
+
+### Overture Delivery
+
+- `Auto-add sub-issues to project` -> `PWF_lADOCZhNHc4BRmMezgT9Ab0` (enabled)
+- `Auto-close issue` -> `PWF_lADOCZhNHc4BRmMezgT9Abs` (disabled)
+- `Item added to project` -> `PWF_lADOCZhNHc4BRmMezgT9AcE` (disabled)
+- `Item closed` -> `PWF_lADOCZhNHc4BRmMezgT9Abk` (disabled)
+- `Pull request linked to issue` -> `PWF_lADOCZhNHc4BRmMezgT9Ab8` (disabled)
+- `Pull request merged` -> `PWF_lADOCZhNHc4BRmMezgT9Abo` (disabled)
+
+### Overture Sandbox
+
+- `Auto-add sub-issues to project` -> `PWF_lADOCZhNHc4BRmMfzgT9AcI` (enabled)
+- `Auto-close issue` -> `PWF_lADOCZhNHc4BRmMfzgT9AcA` (disabled)
+- `Item added to project` -> `PWF_lADOCZhNHc4BRmMfzgT9AcQ` (disabled)
+- `Item closed` -> `PWF_lADOCZhNHc4BRmMfzgT9Abw` (disabled)
+- `Pull request linked to issue` -> `PWF_lADOCZhNHc4BRmMfzgT9AcM` (disabled)
+- `Pull request merged` -> `PWF_lADOCZhNHc4BRmMfzgT9Ab4` (disabled)
+
+## Operational note
+
+This ticket did not verify a native GitHub workflow that automatically places every new
+`BrandByX/overture` issue onto `Overture Delivery`. Because that behavior is not currently
+documented or exposed through a clearly configured project automation here, the supported policy is
+explicit add rather than assumed auto-add.
+
+If a native auto-add rule is later enabled and verified, update this document and the surrounding
+harness docs in the same change.

--- a/docs/references/index.md
+++ b/docs/references/index.md
@@ -1,0 +1,7 @@
+# References Index
+
+Created: 2026-03-13
+
+## Documents
+
+- `github-projects-board-metadata.md`: live board IDs, field IDs, option IDs, and intake policy


### PR DESCRIPTION
#### Context

Ticket #2 is the first repo-side follow-through after the Overture fork baseline. The boards already existed in GitHub, but the live board contract, field IDs, option IDs, and intake policy were not captured in-repo. Closes #2.

#### TL;DR

*Document the live Overture Delivery and Sandbox board contract and add a canonical reference for runtime metadata.*

#### Summary

- add `docs/references/github-projects-board-metadata.md` with board IDs, field IDs, option IDs, and workflow IDs
- add `docs/references/index.md` and wire the references subtree into `AGENTS.md`, `docs/README.md`, and `ARCHITECTURE.md`
- document the current intake policy as explicit add, since no verified repo-issue auto-add rule is configured
- update planning docs so ticket `#2` clearly owns board metadata capture, not just board creation

#### Alternatives

- Keep the board metadata only in the GitHub issue body or PR notes.
  Rejected because future runtime and smoke-test work needs a canonical in-repo reference surface.
- Assume new repo issues auto-add to `Overture Delivery`.
  Rejected because the exposed project workflows do not show a verified repo-issue auto-add rule, so the safe policy is explicit add.

#### Test Plan

- [ ] `make -C elixir all`
- [x] `git diff --check`
- [x] `gh project field-list 6 --owner BrandByX`
- [x] `gh project field-list 5 --owner BrandByX`
- [x] `gh api graphql` to capture board node IDs, `Status` field IDs, option IDs, and workflow IDs

Notes:
- `cd /Users/sidneyl/code/overture/elixir && mise exec -- make all` was run.
- It failed in a pre-existing upstream test: `SymphonyElixir.SSHTest` at `test/symphony_elixir/ssh_test.exs:135` timed out waiting for `ssh.trace`.
- This PR only changes docs and does not touch the SSH subsystem.
