### PR TITLE
Restore Human Review as a manual handoff state

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -379,7 +379,8 @@ Fields:
   - Optional explicit GitHub login filter.
   - `me` is intentionally unsupported in v1.
 - `active_states` (list of strings)
-  - Default: `Todo`, `In Progress`, `Human Review`, `Rework`, `Merging`
+  - Default: `Todo`, `In Progress`
+  - `Human Review` is invalid here because it is a manual handoff state.
 - `terminal_states` (list of strings)
   - Default: `Done`, `Cancelled`, `Duplicate`
 
@@ -590,7 +591,7 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `tracker.repository`: string, required in `owner/repo` form when `tracker.kind=github_projects`
 - `tracker.status_field_name`: string, default `Status`, must resolve to `ProjectV2SingleSelectField`
 - `tracker.assignee`: explicit GitHub login or null; `me` is invalid in v1
-- `tracker.active_states`: list of strings, default `["Todo", "In Progress", "Human Review", "Rework", "Merging"]`
+- `tracker.active_states`: list of strings, default `["Todo", "In Progress"]`
 - `tracker.terminal_states`: list of strings, default `["Done", "Cancelled", "Duplicate"]`
 - `polling.interval_ms`: integer, default `30000`
 - `workspace.root`: path, default `<system-temp>/symphony_workspaces`
@@ -1218,6 +1219,7 @@ GitHub Projects-specific requirements for `tracker.kind == "github_projects"`:
 - `tracker.priority_field_name` must not match `tracker.status_field_name`
 - `tracker.priority_option_map` is only valid when `tracker.priority_field_name` resolves to a
   single-select field
+- `tracker.active_states` must not include `Human Review`; it is a manual handoff state
 - Candidate issue query filters to issue-backed project items whose current project `Status`
   appears in `tracker.active_states`
 - PR-linked project items, draft items, redacted items, archived items, and wrong-repo items are

--- a/docs/product-specs/github-projects-runtime-contract.md
+++ b/docs/product-specs/github-projects-runtime-contract.md
@@ -43,6 +43,7 @@ The target runtime contract supports:
 - every configured priority value must be an integer in `1..4`
 - `tracker.assignee`, when present, must be an explicit GitHub login
 - `tracker.assignee: me` must fail validation clearly
+- `tracker.active_states` must not include `Human Review`; it is a manual handoff state
 
 ## Workflow field semantics
 
@@ -59,6 +60,11 @@ Target options:
 - `Done`
 - `Cancelled`
 - `Duplicate`
+
+Shipped workflow usage:
+
+- active work states: `Todo`, `In Progress`, `Rework`, `Merging`
+- manual handoff state: `Human Review`
 
 Priority is optional and board-configured.
 
@@ -101,6 +107,13 @@ The runtime writes to two different GitHub objects:
 
 - comments go to the linked issue via `content_id`
 - workflow state changes go to the project item via `id`
+
+## Operations note
+
+- GitHub issue and project mutations are attributed to whichever account owns
+  the configured tracker token.
+- Use a dedicated service account or GitHub App token when automation
+  attribution must remain distinct from human operators.
 
 ## Close reason mapping
 

--- a/elixir/WORKFLOW.md
+++ b/elixir/WORKFLOW.md
@@ -9,7 +9,6 @@ tracker:
   active_states:
     - Todo
     - In Progress
-    - Human Review
     - Merging
     - Rework
   terminal_states:
@@ -118,9 +117,12 @@ The agent should be able to talk to the configured tracker. If the required trac
 - `Todo` -> queued; immediately transition to `In Progress` before active work.
   - Special case: if a PR is already attached, treat as feedback/rework loop (run full PR feedback sweep, address or explicitly push back, revalidate, return to `Human Review`).
 - `In Progress` -> implementation actively underway.
-- `Human Review` -> PR is attached and validated; waiting on human approval.
+- `Human Review` -> manual handoff state after the PR is attached and validated.
+  No agent session should run here. Humans move the issue to `Rework` when
+  changes are requested or to `Merging` when it is approved.
 - `Merging` -> approved by human; execute the `land` skill flow (do not call `gh pr merge` directly).
-- `Rework` -> reviewer requested changes; planning + implementation required.
+- `Rework` -> reviewer requested changes or a human deliberately moved the issue
+  back into active work. Planning + implementation required.
 - `Done` -> terminal state; no further action required.
 
 ## Step 0: Determine current ticket state and route
@@ -132,7 +134,7 @@ The agent should be able to talk to the configured tracker. If the required trac
    - `Todo` -> immediately move to `In Progress`, then ensure bootstrap workpad comment exists (create if missing), then start execution flow.
      - If PR is already attached, start by reviewing all open PR comments and deciding required changes vs explicit pushback responses.
    - `In Progress` -> continue execution flow from current scratchpad comment.
-   - `Human Review` -> wait and poll for decision/review updates.
+   - `Human Review` -> do not code, comment, or mutate state; shut down immediately if invoked here.
    - `Merging` -> on entry, open and follow `.codex/skills/land/SKILL.md`; do not call `gh pr merge` directly.
    - `Rework` -> run rework flow.
    - `Done` -> do nothing and shut down.
@@ -257,12 +259,11 @@ Use this only when completion is blocked by missing required tools or missing au
 
 ## Step 3: Human Review and merge handling
 
-1. When the issue is in `Human Review`, do not code or change ticket content.
-2. Poll for updates as needed, including GitHub PR review comments from humans and bots.
-3. If review feedback requires changes, move the issue to `Rework` and follow the rework flow.
-4. If approved, human moves the issue to `Merging`.
-5. When the issue is in `Merging`, open and follow `.codex/skills/land/SKILL.md`, then run the `land` skill in a loop until the PR is merged. Do not call `gh pr merge` directly.
-6. After merge is complete, move the issue to `Done`.
+1. `Human Review` is a manual handoff state. No agent session should continue or start there.
+2. Humans move the issue to `Rework` when changes are requested.
+3. Humans move the issue to `Merging` when it is approved.
+4. When the issue is in `Merging`, open and follow `.codex/skills/land/SKILL.md`, then run the `land` skill in a loop until the PR is merged. Do not call `gh pr merge` directly.
+5. After merge is complete, move the issue to `Done`.
 
 ## Step 4: Rework handling
 
@@ -301,7 +302,8 @@ Use this only when completion is blocked by missing required tools or missing au
   link to the current issue, and `blockedBy` when the follow-up depends on the
   current issue.
 - Do not move to `Human Review` unless the `Completion bar before Human Review` is satisfied.
-- In `Human Review`, do not make changes; wait and poll.
+- In `Human Review`, do not make changes and do not continue running. It is a
+  manual handoff state.
 - If state is terminal (`Done`), do nothing and shut down.
 - Keep issue text concise, specific, and reviewer-oriented.
 - If blocked and no workpad exists yet, add one blocker comment describing blocker, impact, and next unblock action.

--- a/elixir/lib/symphony_elixir/config.ex
+++ b/elixir/lib/symphony_elixir/config.ex
@@ -117,6 +117,7 @@ defmodule SymphonyElixir.Config do
 
   defp validate_semantics(settings) do
     normalized_tracker_assignee = normalize_tracker_assignee(settings.tracker.assignee)
+    normalized_active_states = normalize_tracker_active_states(settings.tracker.active_states)
     priority_field_name = normalize_optional_string(settings.tracker.priority_field_name)
     priority_option_map = settings.tracker.priority_option_map
 
@@ -157,6 +158,9 @@ defmodule SymphonyElixir.Config do
       settings.tracker.kind == "github_projects" and normalized_tracker_assignee == "me" ->
         {:error, {:invalid_workflow_config, "tracker.assignee: me is not supported for github_projects; use an explicit GitHub login"}}
 
+      settings.tracker.kind == "github_projects" and human_review_active?(normalized_active_states) ->
+        {:error, {:invalid_workflow_config, "tracker.active_states must not include Human Review; it is a manual handoff state"}}
+
       true ->
         validate_tracker_backend(settings)
     end
@@ -181,6 +185,30 @@ defmodule SymphonyElixir.Config do
   end
 
   defp normalize_tracker_assignee(_assignee), do: nil
+
+  # Normalize configured active state names for semantic validation.
+  #
+  # Downcases each string state name so validation can reject reserved workflow
+  # states regardless of YAML capitalization.
+  #
+  # Returns the normalized state-name list.
+  defp normalize_tracker_active_states(active_states) when is_list(active_states) do
+    Enum.map(active_states, &Schema.normalize_issue_state/1)
+  end
+
+  defp normalize_tracker_active_states(_active_states), do: []
+
+  # Detect whether the workflow incorrectly treats Human Review as active.
+  #
+  # `Human Review` is a manual handoff state in the shipped GitHub workflow and
+  # must not appear in `tracker.active_states`.
+  #
+  # Returns `true` when `Human Review` is configured as active.
+  defp human_review_active?(active_states) when is_list(active_states) do
+    Enum.any?(active_states, &(&1 == "human review"))
+  end
+
+  defp human_review_active?(_active_states), do: false
 
   # Normalize an optional workflow string setting.
   #

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -55,7 +55,7 @@ defmodule SymphonyElixir.Config.Schema do
       field(:priority_field_name, :string)
       field(:priority_option_map, :map)
       field(:assignee, :string)
-      field(:active_states, {:array, :string}, default: ["Todo", "In Progress", "Human Review", "Rework", "Merging"])
+      field(:active_states, {:array, :string}, default: ["Todo", "In Progress"])
       field(:terminal_states, {:array, :string}, default: ["Done", "Cancelled", "Duplicate"])
     end
 

--- a/elixir/test/support/live_smoke_support.exs
+++ b/elixir/test/support/live_smoke_support.exs
@@ -26,7 +26,7 @@ defmodule SymphonyElixir.LiveSmokeSupport do
   @pull_request_page_size 20
   @marker_file_name "overture-live-smoke-marker.txt"
   @trace_file_name "overture-live-smoke.trace"
-  @active_states ["Todo", "In Progress", "Human Review", "Rework", "Merging"]
+  @active_states ["Todo", "In Progress", "Rework", "Merging"]
   @terminal_states ["Done", "Cancelled", "Duplicate"]
   @bootstrap_query """
   query OvertureLiveSmokeBootstrap(
@@ -416,6 +416,34 @@ defmodule SymphonyElixir.LiveSmokeSupport do
       hold_codex_binary: hold_codex_binary,
       bootstrap: bootstrap
     }
+  end
+
+  @doc """
+  Write a deterministic fake Codex binary that moves one issue to one status.
+
+  Uses the normal app-server protocol, leaves the standard marker comment, and
+  updates the requested project status. Closing the linked issue is optional so
+  smoke scenarios can model both handoff and terminal transitions.
+
+  Returns `:ok`.
+  """
+  @spec write_status_codex!(map(), map(), String.t(), keyword()) :: :ok
+  def write_status_codex!(context, issue_fixture, status_name, opts \\ [])
+      when is_map(context) and is_map(issue_fixture) and is_binary(status_name) and is_list(opts) do
+    close_issue? = Keyword.get(opts, :close_issue?, false)
+
+    write_fake_codex!(
+      context.codex_binary,
+      context.trace_file,
+      context.marker_content,
+      issue_fixture,
+      context.bootstrap.status_field,
+      context.bootstrap.project_id,
+      target_status_name: status_name,
+      close_issue?: close_issue?
+    )
+
+    :ok
   end
 
   @doc """
@@ -918,6 +946,37 @@ defmodule SymphonyElixir.LiveSmokeSupport do
   end
 
   @doc """
+  Wait until one live smoke project item reaches one workflow state.
+
+  Polls the live sandbox board until the target project item reports the
+  requested status name. Use this to prove handoff states settle before making
+  follow-on runtime assertions.
+
+  Returns `:ok`.
+  """
+  @spec wait_for_project_item_state!(map(), String.t(), String.t(), keyword()) :: :ok
+  def wait_for_project_item_state!(context, item_id, status_name, opts \\ [])
+      when is_map(context) and is_binary(item_id) and is_binary(status_name) and is_list(opts) do
+    timeout_ms = Keyword.get(opts, :timeout_ms, 10_000)
+    interval_ms = Keyword.get(opts, :interval_ms, 100)
+
+    wait_until!(
+      fn ->
+        if project_item_state(context, item_id) == status_name do
+          :ok
+        else
+          false
+        end
+      end,
+      timeout_ms,
+      interval_ms,
+      "Timed out waiting for the live smoke item #{item_id} to reach #{status_name}."
+    )
+
+    :ok
+  end
+
+  @doc """
   Assert that the PR-linked project item stayed non-runnable.
 
   The smoke run should leave the PR-backed item in the same status it had
@@ -1178,7 +1237,17 @@ defmodule SymphonyElixir.LiveSmokeSupport do
   # item into `Done`.
   #
   # Returns `:ok`.
-  defp write_fake_codex!(path, trace_file, marker_content, issue_fixture, status_field, project_id) do
+  defp write_fake_codex!(path, trace_file, marker_content, issue_fixture, status_field, project_id, opts \\ []) do
+    target_status_name = Keyword.get(opts, :target_status_name, "Done")
+    close_issue? = Keyword.get(opts, :close_issue?, target_status_name == "Done")
+
+    status_call_id =
+      if target_status_name == "Done" and close_issue? do
+        "call-live-smoke-done"
+      else
+        "call-live-smoke-status"
+      end
+
     comment_call =
       Jason.encode!(%{
         "id" => 101,
@@ -1199,13 +1268,13 @@ defmodule SymphonyElixir.LiveSmokeSupport do
         }
       })
 
-    done_call =
+    status_call =
       Jason.encode!(%{
         "id" => 102,
         "method" => "item/tool/call",
         "params" => %{
           "name" => "github_graphql",
-          "callId" => "call-live-smoke-done",
+          "callId" => status_call_id,
           "threadId" => "thread-live-smoke",
           "turnId" => "turn-live-smoke",
           "arguments" => %{
@@ -1216,7 +1285,7 @@ defmodule SymphonyElixir.LiveSmokeSupport do
               "projectId" => project_id,
               "itemId" => issue_fixture.item_id,
               "fieldId" => status_field.id,
-              "optionId" => status_field.option_ids_by_name["Done"]
+              "optionId" => status_field.option_ids_by_name[target_status_name]
             }
           }
         }
@@ -1277,15 +1346,26 @@ defmodule SymphonyElixir.LiveSmokeSupport do
           emit_json '#{comment_call}'
           ;;
         5)
-          emit_json '#{done_call}'
+          emit_json '#{status_call}'
           ;;
-        6)
-          emit_json '#{close_call}'
-          ;;
-        7)
-          emit_json '#{completed_response}'
-          exit 0
-          ;;
+    #{if close_issue? do
+      """
+            6)
+              emit_json '#{close_call}'
+              ;;
+            7)
+              emit_json '#{completed_response}'
+              exit 0
+              ;;
+      """
+    else
+      """
+            6)
+              emit_json '#{completed_response}'
+              exit 0
+              ;;
+      """
+    end}
         *)
           exit 0
           ;;

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -1,6 +1,6 @@
 defmodule SymphonyElixir.TestSupport do
   @workflow_prompt "You are an agent for this repository."
-  @default_tracker_active_states ["Todo", "In Progress", "Human Review", "Rework", "Merging"]
+  @default_tracker_active_states ["Todo", "In Progress"]
   @default_tracker_terminal_states ["Done", "Cancelled", "Duplicate"]
   defmodule FakeGitHubProjectsClient do
     @moduledoc false

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -16,7 +16,7 @@ defmodule SymphonyElixir.CoreTest do
 
     config = Config.settings!()
     assert config.polling.interval_ms == 30_000
-    assert config.tracker.active_states == ["Todo", "In Progress", "Human Review", "Rework", "Merging"]
+    assert config.tracker.active_states == ["Todo", "In Progress"]
     assert config.tracker.terminal_states == ["Done", "Cancelled", "Duplicate"]
     assert config.tracker.assignee == nil
     assert config.agent.max_turns == 20
@@ -43,6 +43,13 @@ defmodule SymphonyElixir.CoreTest do
     write_workflow_file!(Workflow.workflow_file_path(), tracker_active_states: "Todo,  Review,")
     assert {:error, {:invalid_workflow_config, message}} = Config.validate!()
     assert message =~ "tracker.active_states"
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_active_states: ["Todo", "Human Review"]
+    )
+
+    assert {:error, {:invalid_workflow_config, message}} = Config.validate!()
+    assert message =~ "tracker.active_states must not include Human Review"
 
     write_workflow_file!(Workflow.workflow_file_path(),
       tracker_api_token: "token",
@@ -397,6 +404,70 @@ defmodule SymphonyElixir.CoreTest do
 
       refute Map.has_key?(updated_state.running, issue_id)
       refute MapSet.member?(updated_state.claimed, issue_id)
+      refute Process.alive?(agent_pid)
+      assert File.exists?(workspace)
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "human review issue state stops running agent without cleaning workspace" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-human-review-reconcile-#{System.unique_integer([:positive])}"
+      )
+
+    issue_id = "issue-human-review"
+    issue_identifier = "MT-555A"
+    workspace = Path.join(test_root, issue_identifier)
+
+    try do
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: test_root,
+        tracker_active_states: ["Todo", "In Progress", "Rework", "Merging"],
+        tracker_terminal_states: ["Done", "Cancelled", "Duplicate"]
+      )
+
+      File.mkdir_p!(test_root)
+      File.mkdir_p!(workspace)
+
+      agent_pid =
+        spawn(fn ->
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      state = %Orchestrator.State{
+        running: %{
+          issue_id => %{
+            pid: agent_pid,
+            ref: nil,
+            identifier: issue_identifier,
+            issue: %Issue{id: issue_id, state: "In Progress", identifier: issue_identifier},
+            started_at: DateTime.utc_now()
+          }
+        },
+        claimed: MapSet.new([issue_id]),
+        codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+        retry_attempts: %{}
+      }
+
+      issue = %Issue{
+        id: issue_id,
+        identifier: issue_identifier,
+        state: "Human Review",
+        title: "Ready for manual review",
+        description: "Stop the agent now",
+        labels: []
+      }
+
+      updated_state = Orchestrator.reconcile_issue_states_for_test([issue], state)
+
+      refute Map.has_key?(updated_state.running, issue_id)
+      refute MapSet.member?(updated_state.claimed, issue_id)
+      refute Map.has_key?(updated_state.retry_attempts, issue_id)
       refute Process.alive?(agent_pid)
       assert File.exists?(workspace)
     after
@@ -1087,6 +1158,8 @@ defmodule SymphonyElixir.CoreTest do
     assert prompt =~ "Do not include \"next steps for user\""
     assert prompt =~ "open and follow `.codex/skills/land/SKILL.md`"
     assert prompt =~ "Do not call `gh pr merge` directly"
+    assert prompt =~ "`Human Review` -> manual handoff state"
+    assert prompt =~ "do not code, comment, or mutate state; shut down immediately if invoked here"
     assert prompt =~ "Continuation context:"
     assert prompt =~ "retry attempt #2"
   end

--- a/elixir/test/symphony_elixir/live_e2e_test.exs
+++ b/elixir/test/symphony_elixir/live_e2e_test.exs
@@ -72,6 +72,41 @@ defmodule SymphonyElixir.LiveE2ETest do
     assert LiveSmokeSupport.pr_item_state!(context) == expected_pr_state
   end
 
+  test "github projects live smoke settles once work is handed off to Human Review" do
+    runtime_context = LiveSmokeSupport.create_runtime_context!()
+    issue_fixture = LiveSmokeSupport.create_issue_fixture!(runtime_context, title_prefix: "Overture live smoke human review", status_name: "Todo")
+    context = Map.put(runtime_context, :issue, issue_fixture)
+    :ok = LiveSmokeSupport.write_status_codex!(context, issue_fixture, "Human Review")
+
+    write_live_workflow!(context)
+    :ok = LiveSmokeSupport.verify_schema_contract!()
+
+    orchestrator_name = Module.concat(__MODULE__, HumanReviewSmokeOrchestrator)
+    {:ok, orchestrator_pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(orchestrator_pid) do
+        Process.exit(orchestrator_pid, :normal)
+      end
+
+      LiveSmokeSupport.cleanup_issue_fixture!(context, issue_fixture)
+      LiveSmokeSupport.cleanup_runtime!(context)
+    end)
+
+    assert LiveSmokeSupport.wait_for_claimed_issue!(orchestrator_pid, issue_fixture.item_id) ==
+             issue_fixture.item_id
+
+    :ok = LiveSmokeSupport.wait_for_project_item_state!(context, issue_fixture.item_id, "Human Review")
+    :ok = LiveSmokeSupport.wait_for_orchestrator_idle!(orchestrator_pid, context, timeout_ms: 10_000)
+
+    refute Enum.any?(LiveSmokeSupport.fetch_candidate_issues!(), &(&1.id == issue_fixture.item_id))
+
+    trace = File.read!(context.trace_file)
+    assert trace =~ "call-live-smoke-comment"
+    assert trace =~ "call-live-smoke-status"
+    refute trace =~ "call-live-smoke-close"
+  end
+
   test "github projects live smoke keeps same-board Todo work blocked until the blocker reaches Done" do
     context = LiveSmokeSupport.create_runtime_context!()
     blocker = LiveSmokeSupport.create_issue_fixture!(context, title_prefix: "Overture live smoke blocker", status_name: "Backlog")

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -508,6 +508,25 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     refute Orchestrator.should_dispatch_issue_for_test(issue, state)
   end
 
+  test "human review issue is not dispatch-eligible" do
+    state = %Orchestrator.State{
+      max_concurrent_agents: 3,
+      running: %{},
+      claimed: MapSet.new(),
+      codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+      retry_attempts: %{}
+    }
+
+    issue = %Issue{
+      id: "human-review-1",
+      identifier: "MT-1008",
+      title: "Waiting on approval",
+      state: "Human Review"
+    }
+
+    refute Orchestrator.should_dispatch_issue_for_test(issue, state)
+  end
+
   test "todo issue with terminal blockers remains dispatch-eligible" do
     state = %Orchestrator.State{
       max_concurrent_agents: 3,


### PR DESCRIPTION
## Summary
- remove  from the active-state defaults and shipped GitHub workflow
- hard-fail config validation when  includes 
- update docs, prompt text, regressions, and live smoke to prove handoff work settles instead of continuing

## Validation
- 
- 
- 