### PR TITLE
Make browser QA selection workpad-driven

### DIFF
--- a/.codex/skills/browser-qa/SKILL.md
+++ b/.codex/skills/browser-qa/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: browser-qa
 description:
-  Use the repo-owned isolated browser QA contract for app-touching work and
-  publish deterministic PR evidence through one persistent QA comment.
+  Use the repo-owned isolated browser QA contract for ticket-selected
+  browser-visible evidence and publish deterministic PR evidence through one
+  persistent QA comment.
 ---
 
 # Browser QA
@@ -11,20 +12,23 @@ description:
 
 Overture-managed repos must use one browser QA path: isolated PinchTab +
 Chromium + Xvfb inside Docker, with framebuffer captures as the only valid
-browser evidence source.
+browser evidence source. Repos provide a reusable browser QA catalog; the issue
+workpad selects which evidence targets are required for the current ticket.
 
 ## Required repo surfaces
 
 - `.codex/skills/browser-qa/SKILL.md`
 - `scripts/<repo-namespace>/browser-qa.sh`
 - `scripts/<repo-namespace>/browser-auth.sh`
-- `scripts/<repo-namespace>/browser-qa.plan.json`
+- `scripts/<repo-namespace>/browser-qa.catalog.json`
 - optional `scripts/<repo-namespace>/browser-qa-scenarios.mjs`
 
 ## Contract
 
+- Browser QA is required only when the issue workpad `### Browser QA Plan`
+  says `Status: Required`.
 - Required PNGs always come from the isolated container display.
-- Optional MP4s are generated only for named scenarios.
+- Optional MP4s are generated only for selected named scenarios.
 - Browser QA must not use host-browser screenshots, environment screenshot
   capture, or page-only CDP screenshots as final evidence.
 - Publish evidence through one persistent PR comment headed
@@ -33,6 +37,7 @@ browser evidence source.
 ## Usage
 
 When a repo ships the required surfaces, follow the repo-local instructions in
-its `browser-qa` skill and scripts. If the repo does not yet implement this
-contract, stop and surface the missing surface as a blocker instead of falling
-back to host-browser capture.
+its `browser-qa` skill and scripts, and capture only the stills/videos selected
+for the current ticket. If the repo does not yet implement this contract, stop
+and surface the missing surface as a blocker instead of falling back to
+host-browser capture.

--- a/docs/references/browser-qa-contract-20260314.md
+++ b/docs/references/browser-qa-contract-20260314.md
@@ -46,6 +46,7 @@ also live under the same runtime root.
 - Do not use host-browser screenshots as browser QA evidence.
 - Do not use environment screenshot tooling as a browser QA fallback.
 - Do not use page-only CDP screenshots as final QA evidence.
-- Do not assume any repo-wide default screenshot trio; select evidence per
-  ticket from the repo catalog.
+- Do not assume any repo-wide default screenshot set. Select evidence per
+  ticket based on the changed behavior, using repo catalog entries only when
+  they are a good reusable fit.
 - Keep one persistent PR comment headed `## Manual QA Evidence`.

--- a/docs/references/browser-qa-contract-20260314.md
+++ b/docs/references/browser-qa-contract-20260314.md
@@ -5,42 +5,47 @@
 
 This document defines the shared browser QA contract for Overture-managed repos.
 
-All app-touching browser QA must run through an isolated PinchTab + Chromium +
-Xvfb container flow. Final browser evidence comes from the container
-framebuffer only, not from the operator desktop, host browser, or page-only CDP
-captures.
+Browser-visible QA must run through an isolated PinchTab + Chromium + Xvfb
+container flow. Final browser evidence comes from the container framebuffer
+only, not from the operator desktop, host browser, or page-only CDP captures.
+Repos provide reusable browser QA catalog entries; the issue workpad `### Browser
+QA Plan` selects which artifacts are actually required for the current ticket.
 
 ## Required repo surfaces
 
 - `.codex/skills/browser-qa/SKILL.md`
 - `scripts/<repo-namespace>/browser-qa.sh`
-- `scripts/<repo-namespace>/browser-qa.plan.json`
+- `scripts/<repo-namespace>/browser-qa.catalog.json`
 - `scripts/<repo-namespace>/browser-auth.sh`
 - optional `scripts/<repo-namespace>/browser-qa-scenarios.mjs`
 
 ## CLI contract
 
-- `scripts/<repo-namespace>/browser-qa.sh capture [--video-scenario <name> ...]`
-- `scripts/<repo-namespace>/browser-qa.sh publish`
+- `scripts/<repo-namespace>/browser-qa.sh capture --still <name> ... [--video-scenario <name> ...] [--request-file <path>]`
+- `scripts/<repo-namespace>/browser-qa.sh publish [--manifest <path> | --not-applicable]`
+- `scripts/<repo-namespace>/browser-qa.sh clean`
 - `scripts/<repo-namespace>/browser-auth.sh resolve --profile <name> --app-url <container-url>`
 
 ## Artifact contract
 
 Committed artifacts live under `docs/generated/browser-qa/<branch-slug>/`.
 
-Required PNG naming:
+Selected PNG naming:
 - `<name>.png`
 
-Optional video naming:
+Selected video naming:
 - `<name>.mp4`
 - `<name>-poster.png`
 
 Runtime-only manifests and logs live under `.symphony/runtime/browser-qa/<run-id>/`
-or an equivalent repo-local runtime directory.
+or an equivalent repo-local runtime directory. A latest-manifest pointer may
+also live under the same runtime root.
 
 ## Guardrails
 
 - Do not use host-browser screenshots as browser QA evidence.
 - Do not use environment screenshot tooling as a browser QA fallback.
 - Do not use page-only CDP screenshots as final QA evidence.
+- Do not assume any repo-wide default screenshot trio; select evidence per
+  ticket from the repo catalog.
 - Keep one persistent PR comment headed `## Manual QA Evidence`.

--- a/elixir/WORKFLOW.md
+++ b/elixir/WORKFLOW.md
@@ -169,6 +169,10 @@ The agent should be able to talk to the configured tracker. If the required trac
     - If changes are user-facing, include a UI walkthrough acceptance criterion that describes the end-to-end user path to validate.
     - If changes touch app files or app behavior, add explicit app-specific flow checks to `Acceptance Criteria` in the workpad (for example: launch path, changed interaction path, and expected result path).
     - If the ticket description/comment context includes `Validation`, `Test Plan`, or `Testing` sections, copy those requirements into the workpad `Acceptance Criteria` and `Validation` sections as required checkboxes (no optional downgrade).
+    - Add and fill a `### Browser QA Plan` section before implementation starts:
+      - use `Status: Required` only when acceptance depends on browser-rendered UI, browser navigation, visible browser state, or browser interaction proof
+      - use `Status: Not applicable` for backend, API, runtime, billing, schema, test, or docs work whose acceptance does not depend on browser-visible behavior
+      - when `Status: Required`, list at least one selected still or video target and what each one proves
 7.  Run a principal-style self-review of the plan and refine it in the comment.
 8.  Before implementing, capture a concrete reproduction signal and record it in the workpad `Notes` section (command/output, screenshot, or deterministic UI behavior).
 9.  Run the `pull` skill to sync with latest `origin/main` before any code edits, then record the pull/sync result in the workpad `Notes`.
@@ -227,7 +231,7 @@ Use this only when completion is blocked by missing required tools or missing au
     - You may make temporary local proof edits to validate assumptions (for example: tweak a local build input for `make`, or hardcode a UI account / response path) when this increases confidence.
     - Revert every temporary proof edit before commit/push.
     - Document these temporary proof steps and outcomes in the workpad `Validation`/`Notes` sections so reviewers can follow the evidence.
-    - If app-touching, use the repo-provided isolated browser QA tooling when it exists.
+    - When the workpad `### Browser QA Plan` is `Required`, use the repo-provided isolated browser QA tooling for the selected stills and videos only.
     - Repos that implement browser QA should expose `.codex/skills/browser-qa/SKILL.md`; do not fall back to host-browser or desktop screenshot capture for final QA evidence.
     - If the repo does not yet ship dedicated app-launch or media-upload tooling, run the best available app-specific validation path you can support in-session and record the evidence plus any remaining limitations in the workpad.
 6.  Re-check all acceptance criteria and close any gaps.
@@ -245,12 +249,14 @@ Use this only when completion is blocked by missing required tools or missing au
     - Add a short `### Confusions` section at the bottom when any part of task execution was unclear/confusing, with concise bullets.
     - Do not post any additional completion summary comment.
 11. Before moving to `Human Review`, poll PR feedback and checks:
-    - Read the PR `Manual QA Plan` comment (when present) and use it to sharpen UI/runtime test coverage for the current change.
     - Run the full PR feedback sweep protocol.
     - Confirm PR checks are passing (green) after the latest changes.
     - Confirm every required ticket-provided validation/test-plan item is explicitly marked complete in the workpad.
+    - Confirm the workpad `### Browser QA Plan` is satisfied:
+      - when `Status: Required`, the selected evidence is captured and reflected in the PR evidence comment
+      - when `Status: Not applicable`, no browser QA run is required
     - Repeat this check-address-verify loop until no outstanding comments remain and checks are fully passing.
-    - Re-open and refresh the workpad before state transition so `Plan`, `Acceptance Criteria`, and `Validation` exactly match completed work.
+    - Re-open and refresh the workpad before state transition so `Plan`, `Acceptance Criteria`, `Browser QA Plan`, and `Validation` exactly match completed work.
 12. Only then move issue to `Human Review`.
     - Exception: if blocked by missing required non-GitHub tools/auth per the blocked-access escape hatch, move to `Human Review` with the blocker brief and explicit unblock actions.
 13. For `Todo` tickets that already had a PR attached at kickoff:
@@ -286,7 +292,7 @@ Use this only when completion is blocked by missing required tools or missing au
 - PR feedback sweep is complete and no actionable comments remain.
 - PR checks are green, branch is pushed, and PR is linked on the issue.
 - Required PR metadata is present (`symphony` label).
-- If app-touching, the repo's documented runtime validation and isolated browser QA requirements are complete, or the workpad clearly records the best available validation proof plus any remaining tooling gap.
+- If the workpad `### Browser QA Plan` is `Required`, the repo's documented runtime validation and the selected isolated browser QA evidence are complete, or the workpad clearly records the best available validation proof plus any remaining tooling gap.
 
 ## Guardrails
 
@@ -331,6 +337,16 @@ Use this exact structure for the persistent workpad comment and keep it updated 
 
 - [ ] Criterion 1
 - [ ] Criterion 2
+
+### Browser QA Plan
+
+- Status: Not applicable | Required
+- Reason: <why browser evidence is or is not required>
+- Stills:
+  - `catalog:<name>` -> proves <ticket-specific behavior>
+  - `ad-hoc:<name>` route `<route>` auth `<profile-or-none>` expected path `<path>` expected query `<query-or-none>` -> proves <ticket-specific behavior>
+- Videos:
+  - `catalog:<name>` -> proves <ticket-specific behavior>
 
 ### Validation
 


### PR DESCRIPTION
#### Context

Agents were over-triggering browser QA and collecting generic screenshots instead of ticket-specific evidence.

#### TL;DR

*Make browser QA selection come from the issue workpad instead of broad app-touching rules.*

#### Summary

- add a required `### Browser QA Plan` section to the Overture workpad template
- change active workflow guidance from broad `app-touching` wording to `browser-visible` acceptance wording
- update the shared browser QA skill and contract to use `browser-qa.catalog.json` and ticket-selected evidence

#### Alternatives

- Keep the old broad browser QA trigger.
  This keeps producing low-signal evidence for tickets whose acceptance is not browser-visible.
- Parse the workpad automatically in this pass.
  That would add runtime behavior changes; this PR keeps the workpad as the human/agent source of truth only.

#### Test Plan

- [ ] `make -C elixir all` (`Mix` fails locally because this environment is on Elixir `1.18.4` while the repo requires `~> 1.19`)
- [x] `rg -n "browser-qa\.plan\.json|Manual QA Plan|app-touching" /Users/sidneyl/code/overture --glob '!deps/**' --glob '!node_modules/**' --glob '!.git/**' || true`
  - confirmed active workflow/skill/contract files no longer use the stale browser QA wording